### PR TITLE
Add jackson-annotations dependency and use @JsonIgnore in Slice class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.18.6</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <version>0.2</version>

--- a/src/main/java/com/facebook/slice/Slice.java
+++ b/src/main/java/com/facebook/slice/Slice.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.slice;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.openjdk.jol.info.ClassLayout;
 import sun.misc.Unsafe;
 
@@ -1170,6 +1171,7 @@ public final class Slice
      * Creates a slice output backed by this slice.  Any data written to the
      * slice output will be immediately visible in this slice.
      */
+    @JsonIgnore
     public SliceOutput getOutput()
     {
         return new BasicSliceOutput(this);


### PR DESCRIPTION
## Problem

When upgrading Presto to Jackson 2.18.6, tests fail with infinite recursion error:
```
com.fasterxml.jackson.databind.JsonMappingException:
Document nesting depth (1001) exceeds the maximum allowed (1000)
(through reference chain: ...->io.airlift.slice.Slice["output"]
->io.airlift.slice.BasicSliceOutput["underlyingSlice"]
->io.airlift.slice.Slice["output"]->...)

```

Added @JsonIgnore annotation to exclude getOutput() from JSON serialization

